### PR TITLE
fixed yaml example and added json example of loading file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,18 @@ python main.py -h
 
 Child configs can be updated via YAML or JSON files.
 
+An example of YAML file (e.g. `config/densenet.yaml`)
 ```yaml
-# config/densenet.yaml
-model:
-  name: densenet
-  depth: 12 
+name: densenet
+depth: 12 
+```
+
+An example of JSON file (e.g. `config/densenet.json`)
+```json
+{
+  "name": "densenet",
+  "depth": 12
+}
 ```
 
 For `chika.Config`, the following functions are prepared:


### PR DESCRIPTION
I fixed the YAML example which the original version starts with `model:` was incorrect. Plus, I added a JSON example.